### PR TITLE
Render 404 page for nonexistent posts

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,6 +6,6 @@ class PostsController < ApplicationController
   def show
     @post = Post.find(params[:id])
   rescue Errno::ENOENT
-    render 'public/404', status: 404
+    raise ActionController::RoutingError.new("Sorry, no post exists with slug #{params[:id]}")
   end
 end


### PR DESCRIPTION
I like the idea of the file system & repo having the blog posts. I wondered what would happen if you visited, like http://www.artisanassistant.com/posts/foo and saw it causes some error. This PR swaps one standard Rails error page for another one.

Thanks for making an open source Rails app, I'm looking forward to seeing how it comes along :smile:

Feel free to not use this if it's weird
