### PR TITLE
Increase database portability by using AREL

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,12 +1,22 @@
 class SearchesController < ApplicationController
   def show
-    # Postgres uses ILIKE, sqlite uses LIKE. :cry:
-    like = Rails.env.production? ? "ILIKE" : "LIKE"
+    %i[name phone email credit want notes location].each do |col|
+      @collected_arel = @collected_arel.nil? ?
+                          matches_column(col) :
+                          @collected_arel.or(matches_column(col))
+    end
 
-    @results = %w[name phone email credit want notes location].collect do |col|
-      Customer.where(["#{col} #{like} ?","%#{params[:q]}%"])
-              .where(shop: current_shop)
-              .all
-    end.inject([], &:|)
+    @results = Customer.where(shop: current_shop)
+                       .where(@collected_arel)
+  end
+
+  private
+
+  def customer_table
+    @customer_table ||= Customer.arel_table
+  end
+
+  def matches_column(col)
+    customer_table[col].matches("%#{params[:q]}%")
   end
 end


### PR DESCRIPTION
Using AREL to compose a series of matching statements concatenated with
OR allows us to hit the database once, instead of once for each column
we want to match on, and lets AREL determine if we want LIKE or ILIKE.

Changes to be committed:
  modified:   app/controllers/searches_controller.rb
