### PR TITLE
Fix changed name of repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ $ npm install knex -g
 ## Up and Running
 
 ```
-$ git clone git@github.com:artisan-tattoo/assistant-API-endpoints.git
-$ cd assistant-API-endpoints
+$ git clone git@github.com:artisan-tattoo/assistant-api.git
+$ cd assistant-api
 $ npm install
 $ npm run db:setup
 $ npm start


### PR DESCRIPTION
I was taking a look at the project after the migration to endpoints and noticed the name of the repo had changed, but hadn't been updated in the `Up and Running` section. I kept the capitalization even though it's not maintained on GitHub.