### PR TITLE
remove iojs from the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
-node_js:
-- '0.12'
-- iojs
 sudo: false
+node_js:
+  - '0.12'
 cache:
   directories:
   - node_modules


### PR DESCRIPTION
And re-order it slightly.

The build for this is failing, and we're not actually deploying against it
anyway, and they've now merged, so.