### PR TITLE
Re-dasherize appointments

### DIFF
--- a/migrations/4_create_appointments.js
+++ b/migrations/4_create_appointments.js
@@ -3,7 +3,7 @@ exports.up = function (knex) {
     .createTable('appointments', function (t) {
       t.increments('id');
       t.integer('artist-id').notNullable().references('id').inTable('artists');
-      t.integer('customer-id').notNullable().references('id').inTable('customers');
+      t.integer('customer_id').notNullable().references('id').inTable('customers');
       t.dateTime('date-scheduled').notNullable();
       t.text('description');
     });

--- a/seeds/3_appointments.js
+++ b/seeds/3_appointments.js
@@ -2,7 +2,7 @@ exports.seed = function(knex, Promise) {
   return Promise.join(
     knex('appointments').insert({
       "artist-id": 1,
-      "customer-id": 1,
+      customer_id: 1,
       "date-scheduled": new Date(),
       description: "finish off that sleeve",
     })


### PR DESCRIPTION
When you go from `fooId` to `DS.store('foo')`, we need to go from `foo-id` to `foo_id`. This takes care of this process for appointments.
